### PR TITLE
add calibration_dir and config_file_path to pipeline; minor tweaks to orthorectification.py

### DIFF
--- a/massipipe/orthorectification.py
+++ b/massipipe/orthorectification.py
@@ -84,7 +84,8 @@ class CameraModel:
         """
 
         edge = np.tan(self.cross_track_fov / 2)
-        return np.arctan(np.linspace(-edge, edge, self.n_pix))
+        angles = np.arctan(np.linspace(-edge, edge, self.n_pix))
+        return angles.reshape(-1,1).tolist()
 
     def _ray_rotation_matrices(self, roll: NDArray, pitch: NDArray, yaw: NDArray) -> NDArray:
         """
@@ -624,6 +625,7 @@ class FlatTerrainOrthorectifier:
         )
 
         # Save orthorectified image as GeoTIFF
+        if not geotiff_path.parent.exists(): geotiff_path.parent.mkdir()
         self.file_writer.save_image(ortho_image, wl, transform, utm_epsg, geotiff_path)
 
 


### PR DESCRIPTION
1. Two optional kwargs to `pipeline.py`: 
    1. non-default calibration directory (`calibration_dir`)
    1. non-default config file PATH (`config_file_path`) which replaced the existing `config_file_name`
    
2.  `orthorectifcation.py`: check for existence (and if needed create) parent directory of `geotiff_path`

4.  Possible bug-fix in `orthorectification.py` in the  `looking_angles`  method:
`Rotation.from_euler` seems to expect a nested list-like object for the `angles` arg 
(e.g. `[[1], [2], [3], ...]` instead of `[1, 2, 3…]`)

## Summary by Sourcery

Add configurable calibration and configuration file locations to the pipeline and adjust orthorectification behavior accordingly.

New Features:
- Allow specifying a custom calibration directory for the pipeline.
- Allow specifying a custom configuration file path for the pipeline instead of using a fixed filename.

Bug Fixes:
- Adjust looking angle outputs in orthorectification to match the expected input shape for rotation calculations.
- Ensure the orthorectification GeoTIFF output directory is created if it does not already exist.

Enhancements:
- Improve pipeline logging to include the configuration file path used when running.